### PR TITLE
Add a lot of updates

### DIFF
--- a/draft-edns-otel-trace-ids.md
+++ b/draft-edns-otel-trace-ids.md
@@ -106,6 +106,40 @@ TRACEID=[mnemonic]:[data]
 Where the `mnemonic` is the mnemonic defined for the ID Type and `data` is the ID Data represented as Base16.
 When an unknown Type is encountered, the `mnemonic` MUST be presented as `TYPEN`, where `N` is the decimal representation of the Trace ID Type without leading zeroes.
 
+# Processing of TRACEID
+
+TRACEID SHOULD only be used after mutual agreement between the upstream and downstream server operators.
+
+Performing tracing SHOULD NOT impact DNS query processing.
+Hence, nameservers receiving a malformed TRACEID option or a TRACEID option with an unknown or unsupported Type ID SHOULD ignore this option and continue processing the query.
+It is RECOMMENDED to inform the operator of the nameserver, for example using logging, about malformed or unknown TRACEID options.
+
+Tracing information is collected outside of the DNS transaction and is independent of the DNS query processing.
+The inclusion of a TRACEID option in a query must be seen as a signal from the requestor that tracing should be performed.
+
+This signal can come in two forms; with or without Trace ID Data.
+A query with Trace ID data signals "perform tracing and use this Trace ID".
+A query without Trace ID data signals "perform tracing and inform me of the Trace ID".
+
+## Requests with Trace ID Data
+
+Queries that contain the TRACEID option with Trace ID Data, should perform data collection as configured by the operator.
+As the Trace ID is known, responders MUST NOT include a TRACEID option in responses to queries that contained a TRACEID option.
+
+## Requests without Trace ID Data
+
+Queries that have the TRACEID option without Trace ID Data, should generate a Trace ID and perform data collection as configured by the operator.
+The responder SHOULD include a TRACEID option with Trace ID Data in the response.
+
+## Access Control
+
+It is RECOMMENDED to use access control on who can send TRACEID to initiate data collection, e.g. using IP address allow-lists, TSIG{{!RFC8945}}, or other methods.
+
+When a nameserver receives the TRACEID EDNS option from a system that is allowed to initiate tracing, it should perform any operations required to collect tracing information, as configured by the operator.
+The nameserver MAY include a TRACEID option in outgoing queries to trigger tracing in downstream servers.
+
+When a nameserver receives the TRACEID EDNS option from a system that is not allowed to initiate tracing, it MUST ignore the option and process the query as if no TRACEID option was present.
+
 # Trace ID Types
 
 This specification defines several values for Trace ID Type.
@@ -123,8 +157,10 @@ This specification defines several values for Trace ID Type.
 OpenTelemetry{{OT.WEBSITE}} is an open standard for telemetry data like metrics, logs and traces.
 It is maintained by the Cloud Native Computing Foundation (CNCF){{CNCF.WEBSITE}}.
 
-For OpenTelemetry traces, the TraceID Data field MUST contain a 16 octet Trace ID and MAY have an 8 octet Span ID following it.
+For OpenTelemetry traces that contain Trace ID Data, the TraceID Data field MUST contain a 16 octet Trace ID and MAY have an 8 octet Span ID following it.
 This makes the Trace ID data field either 16 or 24 octets long.
+
+For responses that need a TRACEID option, the TraceID Data field MUST contain a 16 octet Trace ID and MAY have an 8 octet Span ID following it.
 
 ## Private use (247 - 254)
 
@@ -134,26 +170,6 @@ These Trace ID Types can be used for private tracing identifiers.
 
 This Trace ID Type value is reserved for potential future expansion and MUST NOT be used.
 
-# Processing of TRACEID
-
-TRACEID SHOULD only be used after mutual agreement between the upstream and downstream server operators.
-
-Performing tracing SHOULD NOT impact DNS query processing.
-Hence, nameservers receiving a malformed TRACEID option or a TRACEID option with an unknown or unsupported Type ID SHOULD ignore this option an continue processing the query.
-It is RECOMMENDED to inform the operator of the nameserver, for example using logging, about malformed or unknown TRACEID options.
-
-Tracing information is collected outside of the DNS transaction and is independent of the DNS query processing.
-The inclusion of a TRACEID option in a query must be seen as a one-way signal from the requestor that tracing should be performed.
-Responders MUST NOT include a TRACEID option in responses, even to queries that contained a TRACEID option.
-
-## Access control
-
-It is RECOMMENDED to use access control on who can send TRACEID to initiate data collection, e.g. using IP address allow-lists, TSIG{{!RFC8945}}, or other methods.
-
-When a nameserver receives the TRACEID EDNS option from a system that is allowed to initiate tracing, it should perform any operations required to collect tracing information, as configured by the operator.
-The nameserver MAY include a TRACEID option in outgoing queries to trigger tracing in downstream servers.
-
-When a nameserver receives the TRACEID EDNS option from a system that is not allowed to initiate tracing, it MUST ignore the option and process the query as if no TRACEID option was present.
 
 # Security Considerations
 

--- a/draft-edns-otel-trace-ids.md
+++ b/draft-edns-otel-trace-ids.md
@@ -1,6 +1,6 @@
 ---
 title: "Communicating Distributed Trace IDs in EDNS"
-abbrev: "EDNS TRACEIDS"
+abbrev: "EDNS TRACEPARENTS"
 category: info
 
 docname: draft-edns-otel-trace-ids-latest
@@ -50,7 +50,7 @@ informative:
 
 --- abstract
 
-This document defines a new EDNS Option named TRACEID that is used to communicate an identifier for correlating events between DNS systems.
+This document defines a new EDNS Option named TRACEPARENT that is used to communicate an identifier for correlating events between DNS systems.
 
 --- middle
 
@@ -60,7 +60,7 @@ In distributed systems or otherwise interacting systems, operators might want to
 To achieve this correlation, a tracing identifier is generated on the front end system that receives the initial request and passed to downstream systems.
 These downstream systems will generate data related to the request that can be collected and used in system health measurements or trouble shooting.
 
-This document defines a new EDNS{{!RFC6891}} option (TRACEID) to pass tracing identifiers between DNS servers.
+This document defines a new EDNS{{!RFC6891}} option (TRACEPARENT) to pass tracing identifiers between DNS servers.
 
 # Conventions and Definitions
 
@@ -72,7 +72,7 @@ This document defines a new EDNS{{!RFC6891}} option (TRACEID) to pass tracing id
 
 # Wire Format
 
-The TRACEID option has the following wire format:
+The TRACEPARENT option has the following wire format:
 
 ~~~ ascii-art
      0                   1
@@ -97,25 +97,25 @@ Trace ID Data has a variable length, depending on the Trace ID Type.
 # Presentation Format
 
 Even though EDNS options will never appear in DNS zone files, its value could appear in logging or analysis of packet captures.
-The presentation format for TRACEID is as follows:
+The presentation format for TRACEPARENT is as follows:
 
 ~~~ ascii-art
-TRACEID=[mnemonic]:[data]
+TRACEPARENT=[mnemonic]:[data]
 ~~~
 
 Where the `mnemonic` is the mnemonic defined for the ID Type and `data` is the ID Data represented as Base16.
 When an unknown Type is encountered, the `mnemonic` MUST be presented as `TYPEN`, where `N` is the decimal representation of the Trace ID Type without leading zeroes.
 
-# Processing of TRACEID
+# Processing of TRACEPARENT
 
-TRACEID SHOULD only be used after mutual agreement between the upstream and downstream server operators.
+TRACEPARENT SHOULD only be used after mutual agreement between the upstream and downstream server operators.
 
 Performing tracing SHOULD NOT impact DNS query processing.
-Hence, nameservers receiving a malformed TRACEID option or a TRACEID option with an unknown or unsupported Type ID SHOULD ignore this option and continue processing the query.
-It is RECOMMENDED to inform the operator of the nameserver, for example using logging, about malformed or unknown TRACEID options.
+Hence, nameservers receiving a malformed TRACEPARENT option or a TRACEPARENT option with an unknown or unsupported Type ID SHOULD ignore this option and continue processing the query.
+It is RECOMMENDED to inform the operator of the nameserver, for example using logging, about malformed or unknown TRACEPARENT options.
 
 Tracing information is collected outside of the DNS transaction and is independent of the DNS query processing.
-The inclusion of a TRACEID option in a query must be seen as a signal from the requestor that tracing should be performed.
+The inclusion of a TRACEPARENT option in a query must be seen as a signal from the requestor that tracing should be performed.
 
 This signal can come in two forms; with or without Trace ID Data.
 A query with Trace ID data signals "perform tracing and use this Trace ID".
@@ -123,22 +123,22 @@ A query without Trace ID data signals "perform tracing and inform me of the Trac
 
 ## Requests with Trace ID Data
 
-Queries that contain the TRACEID option with Trace ID Data, should perform data collection as configured by the operator.
-As the Trace ID is known, responders MUST NOT include a TRACEID option in responses to queries that contained a TRACEID option.
+Queries that contain the TRACEPARENT option with Trace ID Data, should perform data collection as configured by the operator.
+As the Trace ID is known, responders MUST NOT include a TRACEPARENT option in responses to queries that contained a TRACEPARENT option.
 
 ## Requests without Trace ID Data
 
-Queries that have the TRACEID option without Trace ID Data, should generate a Trace ID and perform data collection as configured by the operator.
-The responder SHOULD include a TRACEID option with Trace ID Data in the response.
+Queries that have the TRACEPARENT option without Trace ID Data, should generate a Trace ID and perform data collection as configured by the operator.
+The responder SHOULD include a TRACEPARENT option with Trace ID Data in the response.
 
 ## Access Control
 
-It is RECOMMENDED to use access control on who can send TRACEID to initiate data collection, e.g. using IP address allow-lists, TSIG{{!RFC8945}}, or other methods.
+It is RECOMMENDED to use access control on who can send TRACEPARENT to initiate data collection, e.g. using IP address allow-lists, TSIG{{!RFC8945}}, or other methods.
 
-When a nameserver receives the TRACEID EDNS option from a system that is allowed to initiate tracing, it should perform any operations required to collect tracing information, as configured by the operator.
-The nameserver MAY include a TRACEID option in outgoing queries to trigger tracing in downstream servers.
+When a nameserver receives the TRACEPARENT EDNS option from a system that is allowed to initiate tracing, it should perform any operations required to collect tracing information, as configured by the operator.
+The nameserver MAY include a TRACEPARENT option in outgoing queries to trigger tracing in downstream servers.
 
-When a nameserver receives the TRACEID EDNS option from a system that is not allowed to initiate tracing, it MUST ignore the option and process the query as if no TRACEID option was present.
+When a nameserver receives the TRACEPARENT EDNS option from a system that is not allowed to initiate tracing, it MUST ignore the option and process the query as if no TRACEPARENT option was present.
 
 # Trace ID Types
 
@@ -160,7 +160,7 @@ It is maintained by the Cloud Native Computing Foundation (CNCF){{CNCF.WEBSITE}}
 For OpenTelemetry traces that contain Trace ID Data, the TraceID Data field MUST contain a 16 octet Trace ID and MAY have an 8 octet Span ID following it.
 This makes the Trace ID data field either 16 or 24 octets long.
 
-For responses that need a TRACEID option, the TraceID Data field MUST contain a 16 octet Trace ID and MAY have an 8 octet Span ID following it.
+For responses that need a TRACEPARENT option, the TraceID Data field MUST contain a 16 octet Trace ID and MAY have an 8 octet Span ID following it.
 
 ## Private use (247 - 254)
 
@@ -190,19 +190,19 @@ TODO request IANA to create a Trace ID Type registry.
 An OpenTelemetry TraceID of 1234567890ABCDEF1234567890ABCDEF is presented as:
 
 ~~~ ascii-art
-TRACEID=OT:1234567890ABCDEF1234567890ABCDEF
+TRACEPARENT=OT:1234567890ABCDEF1234567890ABCDEF
 ~~~
 
 A private Type would be represented as:
 
 ~~~ ascii-art
-TRACEID=PRIVATE250:ABCDEF1234
+TRACEPARENT=PRIVATE250:ABCDEF1234
 ~~~
 
 An unknown Type would be presented as:
 
 ~~~ ascii-art
-TRACEID=TYPE19:FE1234
+TRACEPARENT=TYPE19:FE1234
 ~~~
 
 # Acknowledgments

--- a/draft-edns-otel-trace-ids.md
+++ b/draft-edns-otel-trace-ids.md
@@ -1,6 +1,6 @@
 ---
 title: "Communicating Distributed Trace IDs in EDNS"
-abbrev: "EDNS TRACEPARENTS"
+abbrev: "EDNS TRACEPARENT"
 category: info
 
 docname: draft-edns-otel-trace-ids-latest

--- a/draft-edns-otel-trace-ids.md
+++ b/draft-edns-otel-trace-ids.md
@@ -85,9 +85,22 @@ The TRACEPARENT option has the following wire format:
       +---------------+---------------+
 ~~~
 
-The VERSION field defined in this specification MUST be set to 0.
+The VERSION field indicates how the TRACEPARENT DATA should be interpreted.
+This document defines the following versions:
 
-The TRACEPARENT DATA field for version 0 contains 3 fields: a 16 byte trace-id, an 8 byte parent-id, a 1 byte trace-flags field.
+
+| Version | Usage                    |
+| --------| ------------------------ |
+| 0       | Defined in this document |
+| 252-255 | Private use              |
+
+
+The RESERVED field is for future expansion and MUST be set to 0.
+
+## Version 0
+
+The TRACEPARENT DATA field for version 0 contains 3 fields: a 16 byte trace-id, an 8 byte parent-id, and a 1 byte trace-flags field.
+All these fields are MANDATORY.
 
 ~~~ ascii-art
        0                   1
@@ -106,10 +119,19 @@ The TRACEPARENT DATA field for version 0 contains 3 fields: a 16 byte trace-id, 
 # Presentation Format
 
 Even though EDNS options will never appear in DNS zone files, its value could appear in logging or analysis of packet captures.
-The presentation format for TRACEPARENT follows the traceparent HTTP header from Section 3.2 of {{!W3C.trace-context}}:
+
+The presentation format for TRACEPARENT version 0 follows the traceparent HTTP header from Section 3.2 of {{!W3C.trace-context}}:
 
 ~~~ ascii-art
 TRACEPARENT=[version]-[trace-id]-[parent-id]-[trace-flags]
+~~~
+
+Where each field is represented as Base16 with the hexadecimal characters in lowercase.
+
+The presentation format for unknown and private versions is
+
+~~~ ascii-art
+TRACEPARENT=[version]-[traceparent-data]
 ~~~
 
 Where each field is represented as Base16 with the hexadecimal characters in lowercase.
@@ -123,23 +145,12 @@ This model follows the recommendations of Section 4 of {{!W3C.trace-context}}.
 Performing tracing SHOULD NOT impact DNS query processing.
 Hence, nameservers receiving a malformed TRACEPARENT option SHOULD ignore this option and continue processing the query.
 It is RECOMMENDED to inform the operator of the nameserver, for example using logging, about malformed TRACEPARENT options.
+An nameserver MAY ignore TRACEPARENT options for any reason, including resource constraints.
 
 Tracing information is collected outside of the DNS transaction and is independent of the DNS query processing.
-The inclusion of a TRACEPARENT option in a query must be seen as a signal from the requestor that tracing should be performed.
+The inclusion of a TRACEPARENT option in a query must be seen as a signal from the requester that tracing should be performed.
 
-This signal can come in two forms; with or without Trace ID Data.
-A query with Trace ID data signals "perform tracing and use this Trace ID".
-A query with the EDNS option without Trace Parent data signals "perform tracing and inform me of the Trace ID".
-
-## Requests with Trace ID Data
-
-Queries that contain the TRACEPARENT option with Trace ID Data, should perform data collection as configured by the operator.
-As the Trace Parent is known to the requester and receiver, responders MUST NOT include a TRACEPARENT option in responses to queries that contained a TRACEPARENT option.
-
-## Requests without Trace ID Data
-
-Queries that have the TRACEPARENT option without Trace Parent Data, should generate these values themselves and perform data collection as configured by the operator.
-The responder SHOULD include a TRACEPARENT option in the response containing this information.
+The TRACEPARENT option SHOULD NOT appear in responses from nameserver and it's inclusion in a response is not defined in this document.
 
 ## Access Control
 
@@ -147,7 +158,7 @@ It is RECOMMENDED to use access control on who can send TRACEPARENT to initiate 
 
 When a nameserver receives the TRACEPARENT EDNS option from a system that is allowed to initiate tracing, it should perform any operations required to collect tracing information, as configured by the operator.
 
-When a nameserver receives the TRACEPARENT EDNS option from a system that is not allowed to initiate tracing, it MUST ignore the option and process the query as if no TRACEPARENT option was present.
+When a nameserver receives the TRACEPARENT EDNS option from a system that is not allowed to initiate tracing, it MUST ignore the option and process the query as if no TRACEPARENT option were present.
 
 # Security Considerations
 
@@ -174,6 +185,4 @@ TRACEPARENT=00-1234567890abcdef1234567890abcdef-fedcba0987654321-00
 # Acknowledgments
 {:numbered="false"}
 
-TODO acknowledge.
-
-Job Snijders, Wouter de Vries,
+The authors would like to acknowledge Job Snijders and Wouter de Vries for their initial ideas and expertise of OpenTelemetry.

--- a/draft-edns-otel-trace-ids.md
+++ b/draft-edns-otel-trace-ids.md
@@ -37,11 +37,11 @@ author:
     email: pieter.lexis@powerdns.com
 
 normative:
+  W3C.trace-context:
+    target: https://www.w3.org/TR/2021/REC-trace-context-1-20211123/
+    display: 'W3C Recommendation: Trace Context'
 
 informative:
-  W3C.trace-context-binary:
-    target: https://w3c.github.io/trace-context-binary/
-    title: 'Trace Context: binary protocol'
 
 ...
 
@@ -57,7 +57,7 @@ In distributed systems or otherwise interacting systems, operators might want to
 To achieve this correlation, a tracing identifier is generated on the front end system that receives the initial request and passed to downstream systems.
 These downstream systems will generate data related to the request that can be collected and used in system health measurements or trouble shooting.
 
-This document defines a new EDNS{{!RFC6891}} option (TRACEPARENT) to pass tracing identifiers between DNS servers.
+This document defines a new EDNS{{!RFC6891}} option (TRACEPARENT) to pass tracing identifiers between DNS servers. It follows the W3C recommendation for Trace Context and the traceparent HTTP header, version 00{{!W3C.trace-context}}.
 
 # Conventions and Definitions
 
@@ -72,44 +72,53 @@ This document defines a new EDNS{{!RFC6891}} option (TRACEPARENT) to pass tracin
 The TRACEPARENT option has the following wire format:
 
 ~~~ ascii-art
-     0                   1
-     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5
-    +---------------+---------------+
- 0: |        OPTION-CODE (TBD1)     |
-    +---------------+---------------+
- 2: |         OPTION-LENGTH         |
-    +---------------+---------------+
- 4: |        TRACEPARENT DATA       /
-    +---------------+---------------+
+       0                   1
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5
+      +---------------+---------------+
+ 0:   |        OPTION-CODE (TBD1)     |
+      +---------------+---------------+
+ 2:   |         OPTION-LENGTH         |
+      +---------------+---------------+
+ 4:   |    VERSION    |    RESERVED   |
+      +---------------+---------------+
+ 6:   |       TRACEPARENT DATA        /
+      +---------------+---------------+
 ~~~
 
-The TRACEPARENT DATA field contains the bytes of the Traceparent Binary Format as defined in section 2.1 of {{W3C.trace-context-binary}}.
-For completeness, this format is repeated here:
+The VERSION field defined in this specification MUST be set to 0.
+
+The TRACEPARENT DATA field for version 0 contains 3 fields: a 16 byte trace-id, an 8 byte parent-id, a 1 byte trace-flags field.
 
 ~~~ ascii-art
-traceparent     = version version_format
-version         = 1BYTE
-version_format  = "{ 0x0 }" trace-id "{ 0x1 }" parent-id "{ 0x2 }" trace-flags
-trace-id        = 16BYTES
-parent-id       = 8BYTES
-trace-flags     = 1BYTE
+       0                   1
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5
+      +---------------+---------------+
+ 0:   |           TRACE-ID            /
+      /                               |
+      +---------------+---------------+
+ 16:  |           PARENT-ID           /
+      /                               |
+      +---------------+---------------+
+ 24:  |  TRACEFLAGS   |
+      +---------------+
 ~~~
 
 # Presentation Format
 
 Even though EDNS options will never appear in DNS zone files, its value could appear in logging or analysis of packet captures.
-The presentation format for TRACEPARENT is as follows:
+The presentation format for TRACEPARENT follows the traceparent HTTP header from Section 3.2 of {{!W3C.trace-context}}:
 
 ~~~ ascii-art
-TRACEPARENT=[trace-id],[parent-id],[trace-flags]
+TRACEPARENT=[version]-[trace-id]-[parent-id]-[trace-flags]
 ~~~
 
-Where each field is represented as Base16.
+Where each field is represented as Base16 with the hexadecimal characters in lowercase.
 
 # Processing of TRACEPARENT
 
 TRACEPARENT SHOULD only be used after mutual agreement between the upstream and downstream server operators.
 A nameserver MAY include a TRACEPARENT option in outgoing queries to trigger tracing in downstream servers.
+This model follows the recommendations of Section 4 of {{!W3C.trace-context}}.
 
 Performing tracing SHOULD NOT impact DNS query processing.
 Hence, nameservers receiving a malformed TRACEPARENT option SHOULD ignore this option and continue processing the query.
@@ -159,7 +168,7 @@ None.
 An OpenTelemetry Trace ID of 1234567890ABCDEF1234567890ABCDEF, Parent ID of FEDCBA0987654321, and no Trace Flags is presented as:
 
 ~~~ ascii-art
-TRACEPARENT=1234567890ABCDEF1234567890ABCDEF,FEDCBA0987654321,00
+TRACEPARENT=00-1234567890abcdef1234567890abcdef-fedcba0987654321-00
 ~~~
 
 # Acknowledgments

--- a/draft-edns-otel-trace-ids.md
+++ b/draft-edns-otel-trace-ids.md
@@ -39,12 +39,9 @@ author:
 normative:
 
 informative:
-  OT.WEBSITE:
-    target: https://opentelemetry.io/
-    title: OpenTelemetry Website
-  CNCF.WEBSITE:
-    target: https://www.cncf.io/
-    title: Cloud Native Computing Foundation Website
+  W3C.trace-context-binary:
+    target: https://w3c.github.io/trace-context-binary/
+    title: 'Trace Context: binary protocol'
 
 ...
 
@@ -82,17 +79,21 @@ The TRACEPARENT option has the following wire format:
     +---------------+---------------+
  2: |         OPTION-LENGTH         |
     +---------------+---------------+
- 4: |  VERSION (0)  | TRACE ID TYPE |
+ 4: |        TRACEPARENT DATA       /
     +---------------+---------------+
- 6: |         TRACE ID DATA         /
-    /                               /
-    +---------------+---------------+
-
 ~~~
 
-Version (1 octet) has the value 0 for this specification.
-Trace ID Type (1 octet) describes how the Trace ID data should be interpreted.
-Trace ID Data has a variable length, depending on the Trace ID Type.
+The TRACEPARENT DATA field contains the bytes of the Traceparent Binary Format as defined in section 2.1 of {{W3C.trace-context-binary}}.
+For completeness, this format is repeated here:
+
+~~~ ascii-art
+traceparent     = version version_format
+version         = 1BYTE
+version_format  = "{ 0x0 }" trace-id "{ 0x1 }" parent-id "{ 0x2 }" trace-flags
+trace-id        = 16BYTES
+parent-id       = 8BYTES
+trace-flags     = 1BYTE
+~~~
 
 # Presentation Format
 
@@ -100,76 +101,44 @@ Even though EDNS options will never appear in DNS zone files, its value could ap
 The presentation format for TRACEPARENT is as follows:
 
 ~~~ ascii-art
-TRACEPARENT=[mnemonic]:[data]
+TRACEPARENT=[trace-id],[parent-id],[trace-flags]
 ~~~
 
-Where the `mnemonic` is the mnemonic defined for the ID Type and `data` is the ID Data represented as Base16.
-When an unknown Type is encountered, the `mnemonic` MUST be presented as `TYPEN`, where `N` is the decimal representation of the Trace ID Type without leading zeroes.
+Where each field is represented as Base16.
 
 # Processing of TRACEPARENT
 
 TRACEPARENT SHOULD only be used after mutual agreement between the upstream and downstream server operators.
+A nameserver MAY include a TRACEPARENT option in outgoing queries to trigger tracing in downstream servers.
 
 Performing tracing SHOULD NOT impact DNS query processing.
-Hence, nameservers receiving a malformed TRACEPARENT option or a TRACEPARENT option with an unknown or unsupported Type ID SHOULD ignore this option and continue processing the query.
-It is RECOMMENDED to inform the operator of the nameserver, for example using logging, about malformed or unknown TRACEPARENT options.
+Hence, nameservers receiving a malformed TRACEPARENT option SHOULD ignore this option and continue processing the query.
+It is RECOMMENDED to inform the operator of the nameserver, for example using logging, about malformed TRACEPARENT options.
 
 Tracing information is collected outside of the DNS transaction and is independent of the DNS query processing.
 The inclusion of a TRACEPARENT option in a query must be seen as a signal from the requestor that tracing should be performed.
 
 This signal can come in two forms; with or without Trace ID Data.
 A query with Trace ID data signals "perform tracing and use this Trace ID".
-A query without Trace ID data signals "perform tracing and inform me of the Trace ID".
+A query with the EDNS option without Trace Parent data signals "perform tracing and inform me of the Trace ID".
 
 ## Requests with Trace ID Data
 
 Queries that contain the TRACEPARENT option with Trace ID Data, should perform data collection as configured by the operator.
-As the Trace ID is known, responders MUST NOT include a TRACEPARENT option in responses to queries that contained a TRACEPARENT option.
+As the Trace Parent is known to the requester and receiver, responders MUST NOT include a TRACEPARENT option in responses to queries that contained a TRACEPARENT option.
 
 ## Requests without Trace ID Data
 
-Queries that have the TRACEPARENT option without Trace ID Data, should generate a Trace ID and perform data collection as configured by the operator.
-The responder SHOULD include a TRACEPARENT option with Trace ID Data in the response.
+Queries that have the TRACEPARENT option without Trace Parent Data, should generate these values themselves and perform data collection as configured by the operator.
+The responder SHOULD include a TRACEPARENT option in the response containing this information.
 
 ## Access Control
 
 It is RECOMMENDED to use access control on who can send TRACEPARENT to initiate data collection, e.g. using IP address allow-lists, TSIG{{!RFC8945}}, or other methods.
 
 When a nameserver receives the TRACEPARENT EDNS option from a system that is allowed to initiate tracing, it should perform any operations required to collect tracing information, as configured by the operator.
-The nameserver MAY include a TRACEPARENT option in outgoing queries to trigger tracing in downstream servers.
 
 When a nameserver receives the TRACEPARENT EDNS option from a system that is not allowed to initiate tracing, it MUST ignore the option and process the query as if no TRACEPARENT option was present.
-
-# Trace ID Types
-
-This specification defines several values for Trace ID Type.
-
-
-| Type name     | Mnemonic      | Trace ID Type |
-| ------------- | ------------- | ------------- |
-| OpenTelemetry | OT            | 0             |
-| Private use   | PRIVATENNN (where NNN is the decimal representation of the Type) | 247 - 254     |
-| RESERVED      | RESERVED           | 255           |
-
-
-## OpenTelemetry (0)
-
-OpenTelemetry{{OT.WEBSITE}} is an open standard for telemetry data like metrics, logs and traces.
-It is maintained by the Cloud Native Computing Foundation (CNCF){{CNCF.WEBSITE}}.
-
-For OpenTelemetry traces that contain Trace ID Data, the TraceID Data field MUST contain a 16 octet Trace ID and MAY have an 8 octet Span ID following it.
-This makes the Trace ID data field either 16 or 24 octets long.
-
-For responses that need a TRACEPARENT option, the TraceID Data field MUST contain a 16 octet Trace ID and MAY have an 8 octet Span ID following it.
-
-## Private use (247 - 254)
-
-These Trace ID Types can be used for private tracing identifiers.
-
-## RESERVED (255)
-
-This Trace ID Type value is reserved for potential future expansion and MUST NOT be used.
-
 
 # Security Considerations
 
@@ -180,29 +149,17 @@ TODO Security
 
 # IANA Considerations
 
-TODO request IANA to create a Trace ID Type registry.
+None.
 
 --- back
 
 # Appendix A. Presentation Format Examples
 {:numbered="false"}
 
-An OpenTelemetry TraceID of 1234567890ABCDEF1234567890ABCDEF is presented as:
+An OpenTelemetry Trace ID of 1234567890ABCDEF1234567890ABCDEF, Parent ID of FEDCBA0987654321, and no Trace Flags is presented as:
 
 ~~~ ascii-art
-TRACEPARENT=OT:1234567890ABCDEF1234567890ABCDEF
-~~~
-
-A private Type would be represented as:
-
-~~~ ascii-art
-TRACEPARENT=PRIVATE250:ABCDEF1234
-~~~
-
-An unknown Type would be presented as:
-
-~~~ ascii-art
-TRACEPARENT=TYPE19:FE1234
+TRACEPARENT=1234567890ABCDEF1234567890ABCDEF,FEDCBA0987654321,00
 ~~~
 
 # Acknowledgments

--- a/draft-edns-otel-trace-ids.md
+++ b/draft-edns-otel-trace-ids.md
@@ -1,6 +1,6 @@
 ---
-title: "Communicating OpenTelemetry Trace IDs in EDNS"
-abbrev: "EDNS OTTRACEIDS"
+title: "Communicating Distributed Trace IDs in EDNS"
+abbrev: "EDNS TRACEIDS"
 category: info
 
 docname: draft-edns-otel-trace-ids-latest
@@ -31,30 +31,48 @@ author:
     fullname: Peter van Dijk
     organization: PowerDNS.com B.V.
     email: peter.van.dijk@powerdns.com
+ -
+    fullname: Pieter Lexis
+    organization: PowerDNS.com B.V.
+    email: pieter.lexis@powerdns.com
 
 normative:
 
 informative:
+  OT.WEBSITE:
+    target: https://opentelemetry.io/
+    title: OpenTelemetry Website
+  CNCF.WEBSITE:
+    target: https://www.cncf.io/
+    title: Cloud Native Computing Foundation Website
 
 ...
 
 --- abstract
 
-TODO Abstract
-
+This document defines a new EDNS Option named TRACEID that is used to communicate an identifier for correlating events between DNS systems.
 
 --- middle
 
 # Introduction
 
-TODO Introduction
+In distributed systems or otherwise interacting systems, operators might want to correlate events or know how an incoming request moves through the system.
+To achieve this correlation, a tracing identifier is generated on the front end system that receives the initial request and passed to downstream systems.
+These downstream systems will generate data related to the request that can be collected and used in system health measurements or trouble shooting.
 
+This document defines a new EDNS{{!RFC6891}} option (TRACEID) to pass tracing identifiers between DNS servers.
 
 # Conventions and Definitions
 
 {::boilerplate bcp14-tagged}
 
+* This document uses DNS Terminology as defined in {{!RFC9499}}.
+
+* Base16 is the representation of arbitrary binary data by an even number of case-insensitive hexadecimal digits ({{!RFC4648, Section 8}}).
+
 # Wire Format
+
+The TRACEID option has the following wire format:
 
 ~~~ ascii-art
      0                   1
@@ -62,39 +80,118 @@ TODO Introduction
     +---------------+---------------+
  0: |        OPTION-CODE (TBD1)     |
     +---------------+---------------+
- 2: |    OPTION-LENGTH (18 or 26)   |
+ 2: |         OPTION-LENGTH         |
     +---------------+---------------+
- 4: |   VERSION (0) |   RESERVED    |
+ 4: |  VERSION (0)  | TRACE ID TYPE |
     +---------------+---------------+
- 6: |      TRACE ID (16 octets)     /
-    /                               /
-    |---------------+---------------+
-22: | SPAN ID (optional, 8 octets)  /
+ 6: |         TRACE ID DATA         /
     /                               /
     +---------------+---------------+
 
 ~~~
 
 Version (1 octet) has the value 0 for this specification.
-Reserved (1 octet) MUST also be set to 0.
-The Trace ID is 16 octets long and is mandatory (or not? if empty, receiver selects one, so that empty is just a "please trace" signal. Although then the sender could also just generate a trace ID).
-The optional Span ID is 8 octets long.
+Trace ID Type (1 octet) describes how the Trace ID data should be interpreted.
+Trace ID Data has a variable length, depending on the Trace ID Type.
+
+# Presentation Format
+
+Even though EDNS options will never appear in DNS zone files, its value could appear in logging or analysis of packet captures.
+The presentation format for TRACEID is as follows:
+
+~~~ ascii-art
+TRACEID=[mnemonic]:[data]
+~~~
+
+Where the `mnemonic` is the mnemonic defined for the ID Type and `data` is the ID Data represented as Base16.
+When an unknown Type is encountered, the `mnemonic` MUST be presented as `TYPEN`, where `N` is the decimal representation of the Trace ID Type without leading zeroes.
+
+# Trace ID Types
+
+This specification defines several values for Trace ID Type.
+
+
+| Type name     | Mnemonic      | Trace ID Type |
+| ------------- | ------------- | ------------- |
+| OpenTelemetry | OT            | 0             |
+| Private use   | PRIVATENNN (where NNN is the decimal representation of the Type) | 247 - 254     |
+| RESERVED      | RESERVED           | 255           |
+
+
+## OpenTelemetry (0)
+
+OpenTelemetry{{OT.WEBSITE}} is an open standard for telemetry data like metrics, logs and traces.
+It is maintained by the Cloud Native Computing Foundation (CNCF){{CNCF.WEBSITE}}.
+
+For OpenTelemetry traces, the TraceID Data field MUST contain a 16 octet Trace ID and MAY have an 8 octet Span ID following it.
+This makes the Trace ID data field either 16 or 24 octets long.
+
+## Private use (247 - 254)
+
+These Trace ID Types can be used for private tracing identifiers.
+
+## RESERVED (255)
+
+This Trace ID Type value is reserved for potential future expansion and MUST NOT be used.
+
+# Processing of TRACEID
+
+TRACEID SHOULD only be used after mutual agreement between the upstream and downstream server operators.
+
+Performing tracing SHOULD NOT impact DNS query processing.
+Hence, nameservers receiving a malformed TRACEID option or a TRACEID option with an unknown or unsupported Type ID SHOULD ignore this option an continue processing the query.
+It is RECOMMENDED to inform the operator of the nameserver, for example using logging, about malformed or unknown TRACEID options.
+
+Tracing information is collected outside of the DNS transaction and is independent of the DNS query processing.
+The inclusion of a TRACEID option in a query must be seen as a one-way signal from the requestor that tracing should be performed.
+Responders MUST NOT include a TRACEID option in responses, even to queries that contained a TRACEID option.
+
+## Access control
+
+It is RECOMMENDED to use access control on who can send TRACEID to initiate data collection, e.g. using IP address allow-lists, TSIG{{!RFC8945}}, or other methods.
+
+When a nameserver receives the TRACEID EDNS option from a system that is allowed to initiate tracing, it should perform any operations required to collect tracing information, as configured by the operator.
+The nameserver MAY include a TRACEID option in outgoing queries to trigger tracing in downstream servers.
+
+When a nameserver receives the TRACEID EDNS option from a system that is not allowed to initiate tracing, it MUST ignore the option and process the query as if no TRACEID option was present.
 
 # Security Considerations
 
 TODO Security
 
+* ACL
+* Mutual agreement
 
 # IANA Considerations
 
-This document has no IANA actions.
-
+TODO request IANA to create a Trace ID Type registry.
 
 --- back
+
+# Appendix A. Presentation Format Examples
+{:numbered="false"}
+
+An OpenTelemetry TraceID of 1234567890ABCDEF1234567890ABCDEF is presented as:
+
+~~~ ascii-art
+TRACEID=OT:1234567890ABCDEF1234567890ABCDEF
+~~~
+
+A private Type would be represented as:
+
+~~~ ascii-art
+TRACEID=PRIVATE250:ABCDEF1234
+~~~
+
+An unknown Type would be presented as:
+
+~~~ ascii-art
+TRACEID=TYPE19:FE1234
+~~~
 
 # Acknowledgments
 {:numbered="false"}
 
 TODO acknowledge.
 
-Job Snijders, Wouter de Vries, 
+Job Snijders, Wouter de Vries,


### PR DESCRIPTION
This commit changes the text of the document in several ways:

* It names the EDNS option TRACEID
* It changes the reserved field to the tracing type identifier
  * Adds OpenTelemetry as a type
  * Defines 8 private types
  * Defines 1 reserved type
* Adds a presentation format for the TRACEID option
* Describes how nameservers should handle TRACEID

All these changes do *not* change anything for the current
implementation in PowerDNS Recursor and dnsdist.
